### PR TITLE
Update babel and rename filterFromCollectionByContains to filterFromCollectionByIncludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![npm version](https://badge.fury.io/js/ember-macaroni.svg)](http://badge.fury.io/js/ember-macaroni) [![Build Status](https://travis-ci.org/poteto/ember-macaroni.svg?branch=master)](https://travis-ci.org/poteto/ember-macaroni) [![Ember Observer Score](http://emberobserver.com/badges/ember-macaroni.svg)](http://emberobserver.com/addons/ember-macaroni)
 
-Keep your app code DRY and copypasta free with computed property <strong>mac</strong>a<strong>ro</strong>ni<strong>s</strong> (macros) for Ember.js 1.13.x and greater. 
+Keep your app code DRY and copypasta free with computed property <strong>mac</strong>a<strong>ro</strong>ni<strong>s</strong> (macros) for Ember.js 1.13.x and greater.
 
 ## Why
 Computed property macros (CPM) are great for DRYing up your code, and Ember.js ships with a [few handy computed macros](http://emberjs.com/api/classes/Ember.computed.html). This addon adds a few more functional-style macros, and can be thought of as the "lodash equivalent" of Ember CPM libraries.
@@ -49,7 +49,7 @@ export default Ember.Component.extend({
   - [rejectFromCollectionByKey](#rejectfromcollectionbykey)
   - [rejectFromCollectionByValue](#rejectfromcollectionbyvalue)
   - [filterFromCollectionByKey](#filterfromcollectionbykey)
-  - [filterFromCollectionByContains](#filterfromcollectionbycontains)
+  - [filterFromCollectionByIncludes](#filterfromcollectionbyincludes)
   - [collectionWithoutKey](#collectionwithoutkey)
   - [reduceCollectionByKey](#reducecollectionbykey)
 * [Truth](#truth)
@@ -76,7 +76,7 @@ Returns the first item with a property matching the passed value from a dependen
 - `@param {String} propName` The key name for the property to find by
 - `@param {String} valueKey` The key name that returns the value to find
 
-```js 
+```js
 Ember.Object.extend({
   items: [{ id: 1, name: 'foo' }, { id: 2, name: 'bar' }],
   selectedId: 1,
@@ -94,7 +94,7 @@ Returns the first item with a property matching the passed value.
 - `@param {String} propName` The key name for the property to find by
 - `@param {*} value` The value to match`
 
-```js 
+```js
 Ember.Object.extend({
   items: [{ id: 1, name: 'foo' }, { id: 2, name: 'bar' }],
   selectedItem: findFromCollectionByValue('items', 'id', 1) // { id: 1, name: 'foo' }
@@ -156,7 +156,7 @@ Ember.Object.extend({
 
 **[⬆ back to top](#available-macros)**
 
-#### `filterFromCollectionByContains`
+#### `filterFromCollectionByIncludes`
 
 Returns an array with just the items that are contained in another array.
 
@@ -168,7 +168,7 @@ Returns an array with just the items that are contained in another array.
 Ember.Object.extend({
   items: [{ id: 1, name: 'foo' }, { id: 2, name: 'bar' }],
   selectedId: 1,
-  selectedItem: filterFromCollectionByContains('items', 'id', [1]) // [{ id: 1, name: 'foo' }]
+  selectedItem: filterFromCollectionByIncludes('items', 'id', [1]) // [{ id: 1, name: 'foo' }]
 });
 ```
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -3,7 +3,7 @@ import findFromCollectionByValue from './macros/collection/find-from-collection-
 import rejectFromCollectionByKey from './macros/collection/reject-from-collection-by-key';
 import rejectFromCollectionByValue from './macros/collection/reject-from-collection-by-value';
 import filterFromCollectionByKey from './macros/collection/filter-from-collection-by-key';
-import filterFromCollectionByContains from './macros/collection/filter-from-collection-by-contains';
+import filterFromCollectionByIncludes from './macros/collection/filter-from-collection-by-includes';
 import collectionWithoutKey from './macros/collection/collection-without-key';
 import reduceCollectionByKey from './macros/collection/reduce-collection-by-key';
 
@@ -24,7 +24,7 @@ export {
   rejectFromCollectionByKey,
   rejectFromCollectionByValue,
   filterFromCollectionByKey,
-  filterFromCollectionByContains,
+  filterFromCollectionByIncludes,
   collectionWithoutKey,
   reduceCollectionByKey,
   getPropertiesByKeys,
@@ -44,7 +44,7 @@ export default {
   rejectFromCollectionByKey,
   rejectFromCollectionByValue,
   filterFromCollectionByKey,
-  filterFromCollectionByContains,
+  filterFromCollectionByIncludes,
   collectionWithoutKey,
   reduceCollectionByKey,
   getPropertiesByKeys,

--- a/addon/macros/collection/filter-from-collection-by-includes.js
+++ b/addon/macros/collection/filter-from-collection-by-includes.js
@@ -12,18 +12,18 @@ const {
  * Ember.Object.extend({
  *   items: [{ id: 1, name: 'foo' }, { id: 2, name: 'bar' }],
  *   selectedId: 1,
- *   selectedItem: filterFromCollectionByContains('items', 'id', [1]) // [{ id: 1, name: 'foo' }]
+ *   selectedItem: filterFromCollectionByIncludes('items', 'id', [1]) // [{ id: 1, name: 'foo' }]
  * });
  *
  * @param {String} collectionKey The key name for the collection
  * @param {String} propName The key name for the property to filter by
  * @param {Array} values The array of values to filter
 */
-export default function filterFromCollectionByContains(collectionKey, propName, values = []) {
+export default function filterFromCollectionByIncludes(collectionKey, propName, values = []) {
   return computed(`${collectionKey}.@each.${propName}`, {
     get() {
       return emberArray(get(this, collectionKey))
-        .filter((item) => emberArray(values).contains(get(item, propName)));
+        .filter((item) => emberArray(values).includes(get(item, propName)));
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   ],
   "dependencies": {
     "ember-cli-htmlbars": "^1.0.10",
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^6.14.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^2.1.0",

--- a/tests/unit/macros/collection/filter-from-collection-by-contains-test.js
+++ b/tests/unit/macros/collection/filter-from-collection-by-contains-test.js
@@ -1,15 +1,15 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import { filterFromCollectionByContains } from 'ember-macaroni';
+import { filterFromCollectionByIncludes } from 'ember-macaroni';
 
 const {
   Object: EmberObject,
   get
 } = Ember;
 
-module('ember-macaroni/collection - filterFromCollectionByContains');
+module('ember-macaroni/collection - filterFromCollectionByIncludes');
 
-test('#filterFromCollectionByContains filters a collection by an array of values for a given property', (assert) => {
+test('#filterFromCollectionByIncludes filters a collection by an array of values for a given property', (assert) => {
   assert.expect(1);
 
   const expectedResult = [
@@ -22,7 +22,7 @@ test('#filterFromCollectionByContains filters a collection by an array of values
     { name: 'Jake', type: 'adventureTime' }
   ];
   const Tommy = EmberObject.extend({
-    friends: filterFromCollectionByContains('characters', 'type', ['rugrats', 'RUGRATS'])
+    friends: filterFromCollectionByIncludes('characters', 'type', ['rugrats', 'RUGRATS'])
   });
   const subject = Tommy.create({ characters });
   const result = get(subject, 'friends');


### PR DESCRIPTION
Ember.Array#contains is deprecated and now uses includes to follow along with ESnext. Original ember issue: https://github.com/emberjs/ember.js/issues/13336

This will also keep ember apps from whining about babel 5.x deprecation.